### PR TITLE
Update dependencies, change session token to manage on cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,4 @@ This is used in
  - `getServerSideProps` (`pages/index.tsx`), to pass different data fetching.
  - API handler (`pages/api/form.ts`), to validate form request that is called from the `Home` page
 
- NOTE: For a case that the Descope project manages token response on BODY (in contrast to manage on COOKIES), the Login component set the refresh token on the `DSR` cookie (see `getRefreshToken()` usage).
- This is done in order to be able to use it on `getServerSideProps` data fetching.
-Prefer using this function only for testing, and to manage token response in COOKIES. When Descope project manages token response on cookies, Descope set the refresh token, and `getRefreshToken` is not needed
+ NOTE: In order to simplify the example - the session token is set to be stored on cookie by providing `sessionTokenViaCookie` prop to the `AuthProvider` component. Alternatively , you can also import `getSessionToken` function from `@descope/react-sdk` to get the token.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "next-descope-example",
       "version": "0.1.0",
       "dependencies": {
-        "@descope/node-sdk": "1.0.4",
-        "@descope/react-sdk": "0.1.3",
+        "@descope/node-sdk": "1.0.6",
+        "@descope/react-sdk": "1.0.0",
         "@types/node": "18.11.9",
         "@types/react": "18.0.25",
         "@types/react-dom": "18.0.8",
@@ -45,22 +45,22 @@
       }
     },
     "node_modules/@descope/core-js-sdk": {
-      "version": "0.0.41-alpha.56",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-0.0.41-alpha.56.tgz",
-      "integrity": "sha512-RlhXgsCZU4SgAEatGjdubln+ZVtVewmkD28VlTFDXl2rEN/+vdFDvs6Pv5lvSbBpM0gcZsMyzLZyiq5Md0z5ew==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-1.0.1.tgz",
+      "integrity": "sha512-WchP+UuW/KtORHAsji3eHoPWgZZ54Qc7XTkRgRMf+VlxEuzp+tJP1l87TtDo4OxU62oQ4Cm/bF7Jrfs2iLvEzg==",
       "dependencies": {
         "jwt-decode": "3.1.2",
         "lodash.get": "4.4.2"
       }
     },
     "node_modules/@descope/node-sdk": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@descope/node-sdk/-/node-sdk-1.0.4.tgz",
-      "integrity": "sha512-S5NuycfLiK5Fbqy/KU1VsTIzJB/Un2nJqVlN1sZPqD9n2GrFvk/DCvOvroip1Bh5ryVNPGLmUlp6eyxFhEGCPg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@descope/node-sdk/-/node-sdk-1.0.6.tgz",
+      "integrity": "sha512-23ADl8xGL01ngST3trv6EnnoDo26k88VFb4z7mGhbRXwEilcMNgdBiAD5Osygr4he6CXMSFy8K6Z0Y+XiCzOCg==",
       "dependencies": {
-        "@descope/core-js-sdk": "0.0.41-alpha.56",
-        "jose": "4.11.2",
-        "node-fetch": "2.6.8"
+        "@descope/core-js-sdk": "0.0.42",
+        "jose": "4.12.0",
+        "node-fetch-commonjs": "3.2.4"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -69,63 +69,44 @@
         "tslib": ">=1.14.1"
       }
     },
-    "node_modules/@descope/react-sdk": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@descope/react-sdk/-/react-sdk-0.1.3.tgz",
-      "integrity": "sha512-ejeM8Z8i6pndJ3gYDNyv8GxQb/1WFkik/HZJX5NsV46ezeNB/aRqNUDBLlnx5EhUjWIoiHOUd2Iqm7TE+AMtZg==",
-      "dependencies": {
-        "@descope/web-component": "0.1.4",
-        "react-router-dom": "6.8.0"
-      },
-      "peerDependencies": {
-        "@descope/web-js-sdk": "0.1.2",
-        "@types/react": ">=16",
-        "react": ">=16"
-      }
-    },
-    "node_modules/@descope/web-component": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-0.1.4.tgz",
-      "integrity": "sha512-Ip/cJzHQqcCnPrrp3FPDotU/7TH1mxqEQqhtd3gjGjqYZiEkjZvGjL/QDRd5ZEyrc5HHNjoypuyW9VgQlU/xhQ==",
-      "dependencies": {
-        "@descope/web-js-sdk": "0.1.3"
-      }
-    },
-    "node_modules/@descope/web-component/node_modules/@descope/core-js-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-1.0.0.tgz",
-      "integrity": "sha512-/PVw5vIfTVQUsxbFc3mG1mXtPEeLZiWcVGT8FDFLQXvTYey2cYraSmSpS2Vo1En+RqTr5ZL382KL7ETPkWpYdA==",
+    "node_modules/@descope/node-sdk/node_modules/@descope/core-js-sdk": {
+      "version": "0.0.42",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-0.0.42.tgz",
+      "integrity": "sha512-QbV8FxKVMT6WOzBxl8RCi0nEPPRMsQ8aB4CzXDnedWTv2J9PhAlPb8ROgL+jPDIug5Qzo9ceaLjKUUOiDectMw==",
       "dependencies": {
         "jwt-decode": "3.1.2",
         "lodash.get": "4.4.2"
       }
     },
-    "node_modules/@descope/web-component/node_modules/@descope/web-js-sdk": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-0.1.3.tgz",
-      "integrity": "sha512-gpwBZX2g0p9hxdtnwfREeZ5bMTT2VVpJv3ek1EbeRs5csAL0rM+ymh1zGGzZFEIJDG7ba7hfxjd9WHHG1GuKdw==",
+    "node_modules/@descope/react-sdk": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@descope/react-sdk/-/react-sdk-1.0.0.tgz",
+      "integrity": "sha512-4cXSEtVjUZ+mzG5jOxjEJIWEUjnVTZmIqBdHzKj54+XngpyElDKxau+VgS25MUG0KPTedfzYUEzwZxgW/JzRgQ==",
       "dependencies": {
-        "@descope/core-js-sdk": "1.0.0",
-        "@fingerprintjs/fingerprintjs-pro": "3.8.2",
-        "js-cookie": "3.0.1"
+        "@descope/web-component": "2.0.0",
+        "react-router-dom": "6.8.0"
+      },
+      "peerDependencies": {
+        "@descope/web-js-sdk": "1.0.0",
+        "@types/react": ">=16",
+        "react": ">=16"
       }
     },
-    "node_modules/@descope/web-component/node_modules/@fingerprintjs/fingerprintjs-pro": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.8.2.tgz",
-      "integrity": "sha512-cccPaHhzt2AnXbUEdpMW4/19eous5/WJhNlawq5BJKmmGSHJzjjb0kkNXgC0QlFll1YsoqLAxmGLOYRVVfmTBA==",
+    "node_modules/@descope/web-component": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-2.0.0.tgz",
+      "integrity": "sha512-M6UAEZtfHGF5ZFUktKP9EopxFL1KXe4wkdLNL4TNGZa79WiuleJQR9iwV7KOC5wkg/WzVZGpkz9RNhhNlZD6VA==",
       "dependencies": {
-        "tslib": "^2.4.1"
+        "@descope/web-js-sdk": "1.0.0"
       }
     },
     "node_modules/@descope/web-js-sdk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-0.1.2.tgz",
-      "integrity": "sha512-Xe/BaDbGSUTF8aMt30bXNwJHrP4zv0tEVWvDju+4YUKwZMGMwyQcKA7WQVgr8cnZkHkBKUuhkRJRtHuemH8KDw==",
-      "peer": true,
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.0.0.tgz",
+      "integrity": "sha512-TlCPS8lEyJi/PlUXPyYIfiOrUaLyEItDXBYdcdhTysaDJAyZa9wZZ78b18QlZQV5lLWupvHFlgu4LhmcETAIzA==",
       "dependencies": {
-        "@descope/core-js-sdk": "0.0.41-alpha.56",
-        "@fingerprintjs/fingerprintjs-pro": "3.8.1",
+        "@descope/core-js-sdk": "1.0.1",
+        "@fingerprintjs/fingerprintjs-pro": "3.8.2",
         "js-cookie": "3.0.1"
       }
     },
@@ -152,12 +133,11 @@
       }
     },
     "node_modules/@fingerprintjs/fingerprintjs-pro": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.8.1.tgz",
-      "integrity": "sha512-hIpShbh75po8j7AQQ2a/avI/X4KCe/wXR9B8+yeK9UQpnADBcNBuSCaaBIQDmDoHCxCsS/2hma91dgwt/u+6cA==",
-      "peer": true,
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.8.2.tgz",
+      "integrity": "sha512-cccPaHhzt2AnXbUEdpMW4/19eous5/WJhNlawq5BJKmmGSHJzjjb0kkNXgC0QlFll1YsoqLAxmGLOYRVVfmTBA==",
       "dependencies": {
-        "tslib": "^2.0.1"
+        "tslib": "^2.4.1"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1469,6 +1449,28 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -1522,6 +1524,17 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -1968,9 +1981,9 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/jose": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz",
-      "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.12.0.tgz",
+      "integrity": "sha512-wW1u3cK81b+SFcHjGC8zw87yuyUweEFe0UJirrXEw1NasW00eF7sZjeG3SLBGz001ozxQ46Y9sofDvhBmWFtXQ==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2225,23 +2238,38 @@
         }
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
-      "integrity": "sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==",
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch-commonjs": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/node-fetch-commonjs/-/node-fetch-commonjs-3.2.4.tgz",
+      "integrity": "sha512-bZW7+ldcuuMPLTJk8DufhT6qHDRdljYD0jqBjmrYfcInaYcReX5kK42SQsu/jvtit/tER28yYjnk63PEEmNPtg==",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "formdata-polyfill": "^4.0.10",
+        "web-streams-polyfill": "^3.1.1"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/object-assign": {
@@ -2902,11 +2930,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -3006,18 +3029,12 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which": {
@@ -3098,78 +3115,59 @@
       }
     },
     "@descope/core-js-sdk": {
-      "version": "0.0.41-alpha.56",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-0.0.41-alpha.56.tgz",
-      "integrity": "sha512-RlhXgsCZU4SgAEatGjdubln+ZVtVewmkD28VlTFDXl2rEN/+vdFDvs6Pv5lvSbBpM0gcZsMyzLZyiq5Md0z5ew==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-1.0.1.tgz",
+      "integrity": "sha512-WchP+UuW/KtORHAsji3eHoPWgZZ54Qc7XTkRgRMf+VlxEuzp+tJP1l87TtDo4OxU62oQ4Cm/bF7Jrfs2iLvEzg==",
       "requires": {
         "jwt-decode": "3.1.2",
         "lodash.get": "4.4.2"
       }
     },
     "@descope/node-sdk": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@descope/node-sdk/-/node-sdk-1.0.4.tgz",
-      "integrity": "sha512-S5NuycfLiK5Fbqy/KU1VsTIzJB/Un2nJqVlN1sZPqD9n2GrFvk/DCvOvroip1Bh5ryVNPGLmUlp6eyxFhEGCPg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@descope/node-sdk/-/node-sdk-1.0.6.tgz",
+      "integrity": "sha512-23ADl8xGL01ngST3trv6EnnoDo26k88VFb4z7mGhbRXwEilcMNgdBiAD5Osygr4he6CXMSFy8K6Z0Y+XiCzOCg==",
       "requires": {
-        "@descope/core-js-sdk": "0.0.41-alpha.56",
-        "jose": "4.11.2",
-        "node-fetch": "2.6.8"
-      }
-    },
-    "@descope/react-sdk": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@descope/react-sdk/-/react-sdk-0.1.3.tgz",
-      "integrity": "sha512-ejeM8Z8i6pndJ3gYDNyv8GxQb/1WFkik/HZJX5NsV46ezeNB/aRqNUDBLlnx5EhUjWIoiHOUd2Iqm7TE+AMtZg==",
-      "requires": {
-        "@descope/web-component": "0.1.4",
-        "react-router-dom": "6.8.0"
-      }
-    },
-    "@descope/web-component": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-0.1.4.tgz",
-      "integrity": "sha512-Ip/cJzHQqcCnPrrp3FPDotU/7TH1mxqEQqhtd3gjGjqYZiEkjZvGjL/QDRd5ZEyrc5HHNjoypuyW9VgQlU/xhQ==",
-      "requires": {
-        "@descope/web-js-sdk": "0.1.3"
+        "@descope/core-js-sdk": "0.0.42",
+        "jose": "4.12.0",
+        "node-fetch-commonjs": "3.2.4"
       },
       "dependencies": {
         "@descope/core-js-sdk": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-1.0.0.tgz",
-          "integrity": "sha512-/PVw5vIfTVQUsxbFc3mG1mXtPEeLZiWcVGT8FDFLQXvTYey2cYraSmSpS2Vo1En+RqTr5ZL382KL7ETPkWpYdA==",
+          "version": "0.0.42",
+          "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-0.0.42.tgz",
+          "integrity": "sha512-QbV8FxKVMT6WOzBxl8RCi0nEPPRMsQ8aB4CzXDnedWTv2J9PhAlPb8ROgL+jPDIug5Qzo9ceaLjKUUOiDectMw==",
           "requires": {
             "jwt-decode": "3.1.2",
             "lodash.get": "4.4.2"
           }
-        },
-        "@descope/web-js-sdk": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-0.1.3.tgz",
-          "integrity": "sha512-gpwBZX2g0p9hxdtnwfREeZ5bMTT2VVpJv3ek1EbeRs5csAL0rM+ymh1zGGzZFEIJDG7ba7hfxjd9WHHG1GuKdw==",
-          "requires": {
-            "@descope/core-js-sdk": "1.0.0",
-            "@fingerprintjs/fingerprintjs-pro": "3.8.2",
-            "js-cookie": "3.0.1"
-          }
-        },
-        "@fingerprintjs/fingerprintjs-pro": {
-          "version": "3.8.2",
-          "resolved": "https://registry.npmjs.org/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.8.2.tgz",
-          "integrity": "sha512-cccPaHhzt2AnXbUEdpMW4/19eous5/WJhNlawq5BJKmmGSHJzjjb0kkNXgC0QlFll1YsoqLAxmGLOYRVVfmTBA==",
-          "requires": {
-            "tslib": "^2.4.1"
-          }
         }
       }
     },
-    "@descope/web-js-sdk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-0.1.2.tgz",
-      "integrity": "sha512-Xe/BaDbGSUTF8aMt30bXNwJHrP4zv0tEVWvDju+4YUKwZMGMwyQcKA7WQVgr8cnZkHkBKUuhkRJRtHuemH8KDw==",
-      "peer": true,
+    "@descope/react-sdk": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@descope/react-sdk/-/react-sdk-1.0.0.tgz",
+      "integrity": "sha512-4cXSEtVjUZ+mzG5jOxjEJIWEUjnVTZmIqBdHzKj54+XngpyElDKxau+VgS25MUG0KPTedfzYUEzwZxgW/JzRgQ==",
       "requires": {
-        "@descope/core-js-sdk": "0.0.41-alpha.56",
-        "@fingerprintjs/fingerprintjs-pro": "3.8.1",
+        "@descope/web-component": "2.0.0",
+        "react-router-dom": "6.8.0"
+      }
+    },
+    "@descope/web-component": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-2.0.0.tgz",
+      "integrity": "sha512-M6UAEZtfHGF5ZFUktKP9EopxFL1KXe4wkdLNL4TNGZa79WiuleJQR9iwV7KOC5wkg/WzVZGpkz9RNhhNlZD6VA==",
+      "requires": {
+        "@descope/web-js-sdk": "1.0.0"
+      }
+    },
+    "@descope/web-js-sdk": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.0.0.tgz",
+      "integrity": "sha512-TlCPS8lEyJi/PlUXPyYIfiOrUaLyEItDXBYdcdhTysaDJAyZa9wZZ78b18QlZQV5lLWupvHFlgu4LhmcETAIzA==",
+      "requires": {
+        "@descope/core-js-sdk": "1.0.1",
+        "@fingerprintjs/fingerprintjs-pro": "3.8.2",
         "js-cookie": "3.0.1"
       }
     },
@@ -3190,12 +3188,11 @@
       }
     },
     "@fingerprintjs/fingerprintjs-pro": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.8.1.tgz",
-      "integrity": "sha512-hIpShbh75po8j7AQQ2a/avI/X4KCe/wXR9B8+yeK9UQpnADBcNBuSCaaBIQDmDoHCxCsS/2hma91dgwt/u+6cA==",
-      "peer": true,
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.8.2.tgz",
+      "integrity": "sha512-cccPaHhzt2AnXbUEdpMW4/19eous5/WJhNlawq5BJKmmGSHJzjjb0kkNXgC0QlFll1YsoqLAxmGLOYRVVfmTBA==",
       "requires": {
-        "tslib": "^2.0.1"
+        "tslib": "^2.4.1"
       }
     },
     "@humanwhocodes/config-array": {
@@ -4092,6 +4089,15 @@
         "reusify": "^1.0.4"
       }
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4130,6 +4136,14 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -4426,9 +4440,9 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "jose": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.11.2.tgz",
-      "integrity": "sha512-njj0VL2TsIxCtgzhO+9RRobBvws4oYyCM8TpvoUQwl/MbIM3NFJRR9+e6x0sS5xXaP1t6OCBkaBME98OV9zU5A=="
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.12.0.tgz",
+      "integrity": "sha512-wW1u3cK81b+SFcHjGC8zw87yuyUweEFe0UJirrXEw1NasW00eF7sZjeG3SLBGz001ozxQ46Y9sofDvhBmWFtXQ=="
     },
     "js-cookie": {
       "version": "3.0.1",
@@ -4609,12 +4623,18 @@
         "use-sync-external-store": "1.2.0"
       }
     },
-    "node-fetch": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
-      "integrity": "sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==",
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
+    "node-fetch-commonjs": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/node-fetch-commonjs/-/node-fetch-commonjs-3.2.4.tgz",
+      "integrity": "sha512-bZW7+ldcuuMPLTJk8DufhT6qHDRdljYD0jqBjmrYfcInaYcReX5kK42SQsu/jvtit/tER28yYjnk63PEEmNPtg==",
       "requires": {
-        "whatwg-url": "^5.0.0"
+        "formdata-polyfill": "^4.0.10",
+        "web-streams-polyfill": "^3.1.1"
       }
     },
     "object-assign": {
@@ -5038,11 +5058,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -5117,19 +5132,10 @@
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "requires": {}
     },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "which": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "next-descope-example",
       "version": "0.1.0",
       "dependencies": {
-        "@descope/node-sdk": "1.0.6",
-        "@descope/react-sdk": "1.0.0",
+        "@descope/node-sdk": "1.1.0",
+        "@descope/react-sdk": "1.0.3",
         "@types/node": "18.11.9",
         "@types/react": "18.0.25",
         "@types/react-dom": "18.0.8",
@@ -22,44 +22,33 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.10"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.20.1.tgz",
-      "integrity": "sha512-CGulbEDcg/ND1Im7fUNRZdGXmX2MTWVVZacQi/6DiKE5HNwZ3aVTm5PV4lO8HHz0B2h8WQyvKKjbX5XgTtydsg==",
-      "dependencies": {
-        "core-js-pure": "^3.25.1",
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@descope/core-js-sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-1.0.1.tgz",
-      "integrity": "sha512-WchP+UuW/KtORHAsji3eHoPWgZZ54Qc7XTkRgRMf+VlxEuzp+tJP1l87TtDo4OxU62oQ4Cm/bF7Jrfs2iLvEzg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-1.0.9.tgz",
+      "integrity": "sha512-e8rHQ+QwzuouSpYT90N/Tt14IcIBF1HcHLDb9H/GUU5x1VOXvZ4Dz0DJ08nPjN3kUoRlqLG8p0MvaKrmJ0B2+g==",
       "dependencies": {
+        "eslint-plugin-jsx-a11y": "6.7.1",
         "jwt-decode": "3.1.2",
         "lodash.get": "4.4.2"
       }
     },
     "node_modules/@descope/node-sdk": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@descope/node-sdk/-/node-sdk-1.0.6.tgz",
-      "integrity": "sha512-23ADl8xGL01ngST3trv6EnnoDo26k88VFb4z7mGhbRXwEilcMNgdBiAD5Osygr4he6CXMSFy8K6Z0Y+XiCzOCg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@descope/node-sdk/-/node-sdk-1.1.0.tgz",
+      "integrity": "sha512-aoXYFbytoHVmhqJp0ITCyUtzOR1tTwPO07HVR8mvn25P1/ab5Cl9PF+tBpv2bzTkGdQdEAJedP5w4zFkvIPBaA==",
       "dependencies": {
-        "@descope/core-js-sdk": "0.0.42",
-        "jose": "4.12.0",
+        "@descope/core-js-sdk": "1.0.9",
+        "jose": "4.13.1",
         "node-fetch-commonjs": "3.2.4"
       },
       "engines": {
@@ -69,43 +58,34 @@
         "tslib": ">=1.14.1"
       }
     },
-    "node_modules/@descope/node-sdk/node_modules/@descope/core-js-sdk": {
-      "version": "0.0.42",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-0.0.42.tgz",
-      "integrity": "sha512-QbV8FxKVMT6WOzBxl8RCi0nEPPRMsQ8aB4CzXDnedWTv2J9PhAlPb8ROgL+jPDIug5Qzo9ceaLjKUUOiDectMw==",
-      "dependencies": {
-        "jwt-decode": "3.1.2",
-        "lodash.get": "4.4.2"
-      }
-    },
     "node_modules/@descope/react-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@descope/react-sdk/-/react-sdk-1.0.0.tgz",
-      "integrity": "sha512-4cXSEtVjUZ+mzG5jOxjEJIWEUjnVTZmIqBdHzKj54+XngpyElDKxau+VgS25MUG0KPTedfzYUEzwZxgW/JzRgQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@descope/react-sdk/-/react-sdk-1.0.3.tgz",
+      "integrity": "sha512-yR1gRF2PaZlespixrR46sricGMn5mbEI3wRU3ea3eOTee3Ejh3W5z+EYuzf8g5T/DvypjXCcKJs5OCRFF2CEBg==",
       "dependencies": {
-        "@descope/web-component": "2.0.0",
-        "react-router-dom": "6.8.0"
+        "@descope/web-component": "2.0.14",
+        "react-router-dom": "6.9.0"
       },
       "peerDependencies": {
-        "@descope/web-js-sdk": "1.0.0",
+        "@descope/web-js-sdk": "1.0.8",
         "@types/react": ">=16",
         "react": ">=16"
       }
     },
     "node_modules/@descope/web-component": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-2.0.0.tgz",
-      "integrity": "sha512-M6UAEZtfHGF5ZFUktKP9EopxFL1KXe4wkdLNL4TNGZa79WiuleJQR9iwV7KOC5wkg/WzVZGpkz9RNhhNlZD6VA==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-2.0.14.tgz",
+      "integrity": "sha512-UZMM1ZhbK4QQ8yWZz0qcRrZ+EBT4q4T75778og4j4YTL2oFbq4vyOBNYegzfvQEEv1uBh9lZB4iq42CMRbf09A==",
       "dependencies": {
-        "@descope/web-js-sdk": "1.0.0"
+        "@descope/web-js-sdk": "1.0.8"
       }
     },
     "node_modules/@descope/web-js-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.0.0.tgz",
-      "integrity": "sha512-TlCPS8lEyJi/PlUXPyYIfiOrUaLyEItDXBYdcdhTysaDJAyZa9wZZ78b18QlZQV5lLWupvHFlgu4LhmcETAIzA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.0.8.tgz",
+      "integrity": "sha512-JZide403B91/PYj1jN2ZO8swXQa9jkjagXE7bBF77k596Db/OhChYRIiQTQyleZdqQYiWxch8XkkoSGgz9Tmhg==",
       "dependencies": {
-        "@descope/core-js-sdk": "1.0.1",
+        "@descope/core-js-sdk": "1.0.9",
         "@fingerprintjs/fingerprintjs-pro": "3.8.2",
         "js-cookie": "3.0.1"
       }
@@ -411,9 +391,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.1.tgz",
-      "integrity": "sha512-+eun1Wtf72RNRSqgU7qM2AMX/oHp+dnx7BHk1qhK5ZHzdHTUU4LA1mGG1vT+jMc8sbhG3orvsfOmryjzx2PzQw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.4.0.tgz",
+      "integrity": "sha512-BJ9SxXux8zAg991UmT8slpwpsd31K1dHHbD3Ba4VzD+liLQ4WAMSxQp2d2ZPRPfN0jN2NPRowcSSoM7lCaF08Q==",
       "engines": {
         "node": ">=14"
       }
@@ -627,15 +607,11 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/aria-query": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
       "dependencies": {
-        "@babel/runtime": "^7.10.2",
-        "@babel/runtime-corejs3": "^7.10.2"
-      },
-      "engines": {
-        "node": ">=6.0"
+        "deep-equal": "^2.0.5"
       }
     },
     "node_modules/array-includes": {
@@ -703,18 +679,32 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag=="
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/axe-core": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.1.tgz",
-      "integrity": "sha512-1exVbW0X1O/HSr/WMwnaweyqcWOgZgLiVxdLG34pvSQk4NlYQr9OUy0JLwuhFfuVNQzzqgH57eYzkFBCb3bIsQ==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
+      "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/axobject-query": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
-      "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
+      "integrity": "sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==",
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -817,16 +807,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
-    "node_modules/core-js-pure": {
-      "version": "3.26.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.26.1.tgz",
-      "integrity": "sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -864,6 +844,33 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.0.tgz",
+      "integrity": "sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-get-iterator": "^1.1.2",
+        "get-intrinsic": "^1.1.3",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/deep-is": {
@@ -945,6 +952,25 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1195,22 +1221,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/eslint-plugin-jsx-a11y": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.1.tgz",
-      "integrity": "sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.7.1.tgz",
+      "integrity": "sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.9",
-        "aria-query": "^4.2.2",
-        "array-includes": "^3.1.5",
+        "@babel/runtime": "^7.20.7",
+        "aria-query": "^5.1.3",
+        "array-includes": "^3.1.6",
+        "array.prototype.flatmap": "^1.3.1",
         "ast-types-flow": "^0.0.7",
-        "axe-core": "^4.4.3",
-        "axobject-query": "^2.2.0",
+        "axe-core": "^4.6.2",
+        "axobject-query": "^3.1.1",
         "damerau-levenshtein": "^1.0.8",
         "emoji-regex": "^9.2.2",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^3.3.2",
-        "language-tags": "^1.0.5",
+        "jsx-ast-utils": "^3.3.3",
+        "language-tags": "=1.0.5",
         "minimatch": "^3.1.2",
+        "object.entries": "^1.1.6",
+        "object.fromentries": "^2.0.6",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -1525,6 +1554,14 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -1572,9 +1609,9 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -1660,6 +1697,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/grapheme-splitter": {
@@ -1776,16 +1824,44 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
       "dependencies": {
-        "get-intrinsic": "^1.1.0",
+        "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-bigint": {
@@ -1869,6 +1945,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -1925,6 +2009,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
@@ -1964,6 +2056,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -1975,15 +2093,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/jose": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.12.0.tgz",
-      "integrity": "sha512-wW1u3cK81b+SFcHjGC8zw87yuyUweEFe0UJirrXEw1NasW00eF7sZjeG3SLBGz001ozxQ46Y9sofDvhBmWFtXQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.13.1.tgz",
+      "integrity": "sha512-MSJQC5vXco5Br38mzaQKiq9mwt7lwj2eXpgpRyQYNHYt2lq1PjkWa7DLXX0WVcQLE9HhMh3jPiufS7fhJf+CLQ==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2288,6 +2423,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -2583,11 +2733,11 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-router": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.0.tgz",
-      "integrity": "sha512-760bk7y3QwabduExtudhWbd88IBbuD1YfwzpuDUAlJUJ7laIIcqhMvdhSVh1Fur1PE8cGl84L0dxhR3/gvHF7A==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.9.0.tgz",
+      "integrity": "sha512-51lKevGNUHrt6kLuX3e/ihrXoXCa9ixY/nVWRLlob4r/l0f45x3SzBvYJe3ctleLUQQ5fVa4RGgJOTH7D9Umhw==",
       "dependencies": {
-        "@remix-run/router": "1.3.1"
+        "@remix-run/router": "1.4.0"
       },
       "engines": {
         "node": ">=14"
@@ -2597,12 +2747,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.0.tgz",
-      "integrity": "sha512-hQouduSTywGJndE86CXJ2h7YEy4HYC6C/uh19etM+79FfQ6cFFFHnHyDlzO4Pq0eBUI96E4qVE5yUjA00yJZGQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.9.0.tgz",
+      "integrity": "sha512-/seUAPY01VAuwkGyVBPCn1OXfVbaWGGu4QN9uj0kCPcTyNYgL1ldZpxZUpRU7BLheKQI4Twtl/OW2nHRF1u26Q==",
       "dependencies": {
-        "@remix-run/router": "1.3.1",
-        "react-router": "6.8.0"
+        "@remix-run/router": "1.4.0",
+        "react-router": "6.9.0"
       },
       "engines": {
         "node": ">=14"
@@ -2613,9 +2763,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -2794,6 +2944,17 @@
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "dependencies": {
+        "internal-slot": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -3066,6 +3227,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dependencies": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -3098,75 +3292,56 @@
   },
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-      "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "requires": {
-        "regenerator-runtime": "^0.13.10"
-      }
-    },
-    "@babel/runtime-corejs3": {
-      "version": "7.20.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.20.1.tgz",
-      "integrity": "sha512-CGulbEDcg/ND1Im7fUNRZdGXmX2MTWVVZacQi/6DiKE5HNwZ3aVTm5PV4lO8HHz0B2h8WQyvKKjbX5XgTtydsg==",
-      "requires": {
-        "core-js-pure": "^3.25.1",
-        "regenerator-runtime": "^0.13.10"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@descope/core-js-sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-1.0.1.tgz",
-      "integrity": "sha512-WchP+UuW/KtORHAsji3eHoPWgZZ54Qc7XTkRgRMf+VlxEuzp+tJP1l87TtDo4OxU62oQ4Cm/bF7Jrfs2iLvEzg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-1.0.9.tgz",
+      "integrity": "sha512-e8rHQ+QwzuouSpYT90N/Tt14IcIBF1HcHLDb9H/GUU5x1VOXvZ4Dz0DJ08nPjN3kUoRlqLG8p0MvaKrmJ0B2+g==",
       "requires": {
+        "eslint-plugin-jsx-a11y": "6.7.1",
         "jwt-decode": "3.1.2",
         "lodash.get": "4.4.2"
       }
     },
     "@descope/node-sdk": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@descope/node-sdk/-/node-sdk-1.0.6.tgz",
-      "integrity": "sha512-23ADl8xGL01ngST3trv6EnnoDo26k88VFb4z7mGhbRXwEilcMNgdBiAD5Osygr4he6CXMSFy8K6Z0Y+XiCzOCg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@descope/node-sdk/-/node-sdk-1.1.0.tgz",
+      "integrity": "sha512-aoXYFbytoHVmhqJp0ITCyUtzOR1tTwPO07HVR8mvn25P1/ab5Cl9PF+tBpv2bzTkGdQdEAJedP5w4zFkvIPBaA==",
       "requires": {
-        "@descope/core-js-sdk": "0.0.42",
-        "jose": "4.12.0",
+        "@descope/core-js-sdk": "1.0.9",
+        "jose": "4.13.1",
         "node-fetch-commonjs": "3.2.4"
-      },
-      "dependencies": {
-        "@descope/core-js-sdk": {
-          "version": "0.0.42",
-          "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-0.0.42.tgz",
-          "integrity": "sha512-QbV8FxKVMT6WOzBxl8RCi0nEPPRMsQ8aB4CzXDnedWTv2J9PhAlPb8ROgL+jPDIug5Qzo9ceaLjKUUOiDectMw==",
-          "requires": {
-            "jwt-decode": "3.1.2",
-            "lodash.get": "4.4.2"
-          }
-        }
       }
     },
     "@descope/react-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@descope/react-sdk/-/react-sdk-1.0.0.tgz",
-      "integrity": "sha512-4cXSEtVjUZ+mzG5jOxjEJIWEUjnVTZmIqBdHzKj54+XngpyElDKxau+VgS25MUG0KPTedfzYUEzwZxgW/JzRgQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@descope/react-sdk/-/react-sdk-1.0.3.tgz",
+      "integrity": "sha512-yR1gRF2PaZlespixrR46sricGMn5mbEI3wRU3ea3eOTee3Ejh3W5z+EYuzf8g5T/DvypjXCcKJs5OCRFF2CEBg==",
       "requires": {
-        "@descope/web-component": "2.0.0",
-        "react-router-dom": "6.8.0"
+        "@descope/web-component": "2.0.14",
+        "react-router-dom": "6.9.0"
       }
     },
     "@descope/web-component": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-2.0.0.tgz",
-      "integrity": "sha512-M6UAEZtfHGF5ZFUktKP9EopxFL1KXe4wkdLNL4TNGZa79WiuleJQR9iwV7KOC5wkg/WzVZGpkz9RNhhNlZD6VA==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-2.0.14.tgz",
+      "integrity": "sha512-UZMM1ZhbK4QQ8yWZz0qcRrZ+EBT4q4T75778og4j4YTL2oFbq4vyOBNYegzfvQEEv1uBh9lZB4iq42CMRbf09A==",
       "requires": {
-        "@descope/web-js-sdk": "1.0.0"
+        "@descope/web-js-sdk": "1.0.8"
       }
     },
     "@descope/web-js-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.0.0.tgz",
-      "integrity": "sha512-TlCPS8lEyJi/PlUXPyYIfiOrUaLyEItDXBYdcdhTysaDJAyZa9wZZ78b18QlZQV5lLWupvHFlgu4LhmcETAIzA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.0.8.tgz",
+      "integrity": "sha512-JZide403B91/PYj1jN2ZO8swXQa9jkjagXE7bBF77k596Db/OhChYRIiQTQyleZdqQYiWxch8XkkoSGgz9Tmhg==",
       "requires": {
-        "@descope/core-js-sdk": "1.0.1",
+        "@descope/core-js-sdk": "1.0.9",
         "@fingerprintjs/fingerprintjs-pro": "3.8.2",
         "js-cookie": "3.0.1"
       }
@@ -3330,9 +3505,9 @@
       }
     },
     "@remix-run/router": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.1.tgz",
-      "integrity": "sha512-+eun1Wtf72RNRSqgU7qM2AMX/oHp+dnx7BHk1qhK5ZHzdHTUU4LA1mGG1vT+jMc8sbhG3orvsfOmryjzx2PzQw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.4.0.tgz",
+      "integrity": "sha512-BJ9SxXux8zAg991UmT8slpwpsd31K1dHHbD3Ba4VzD+liLQ4WAMSxQp2d2ZPRPfN0jN2NPRowcSSoM7lCaF08Q=="
     },
     "@rushstack/eslint-patch": {
       "version": "1.2.0",
@@ -3474,12 +3649,11 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "aria-query": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
       "requires": {
-        "@babel/runtime": "^7.10.2",
-        "@babel/runtime-corejs3": "^7.10.2"
+        "deep-equal": "^2.0.5"
       }
     },
     "array-includes": {
@@ -3526,15 +3700,23 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag=="
     },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
+    },
     "axe-core": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.1.tgz",
-      "integrity": "sha512-1exVbW0X1O/HSr/WMwnaweyqcWOgZgLiVxdLG34pvSQk4NlYQr9OUy0JLwuhFfuVNQzzqgH57eYzkFBCb3bIsQ=="
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
+      "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg=="
     },
     "axobject-query": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
-      "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
+      "integrity": "sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==",
+      "requires": {
+        "deep-equal": "^2.0.5"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -3609,11 +3791,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
-    "core-js-pure": {
-      "version": "3.26.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.26.1.tgz",
-      "integrity": "sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ=="
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3640,6 +3817,30 @@
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
+      }
+    },
+    "deep-equal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.0.tgz",
+      "integrity": "sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-get-iterator": "^1.1.2",
+        "get-intrinsic": "^1.1.3",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.9"
       }
     },
     "deep-is": {
@@ -3706,6 +3907,22 @@
         "string.prototype.trimend": "^1.0.5",
         "string.prototype.trimstart": "^1.0.5",
         "unbox-primitive": "^1.0.2"
+      }
+    },
+    "es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
       }
     },
     "es-shim-unscopables": {
@@ -3901,22 +4118,25 @@
       }
     },
     "eslint-plugin-jsx-a11y": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.6.1.tgz",
-      "integrity": "sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.7.1.tgz",
+      "integrity": "sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==",
       "requires": {
-        "@babel/runtime": "^7.18.9",
-        "aria-query": "^4.2.2",
-        "array-includes": "^3.1.5",
+        "@babel/runtime": "^7.20.7",
+        "aria-query": "^5.1.3",
+        "array-includes": "^3.1.6",
+        "array.prototype.flatmap": "^1.3.1",
         "ast-types-flow": "^0.0.7",
-        "axe-core": "^4.4.3",
-        "axobject-query": "^2.2.0",
+        "axe-core": "^4.6.2",
+        "axobject-query": "^3.1.1",
         "damerau-levenshtein": "^1.0.8",
         "emoji-regex": "^9.2.2",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^3.3.2",
-        "language-tags": "^1.0.5",
+        "jsx-ast-utils": "^3.3.3",
+        "language-tags": "=1.0.5",
         "minimatch": "^3.1.2",
+        "object.entries": "^1.1.6",
+        "object.fromentries": "^2.0.6",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -4137,6 +4357,14 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -4172,9 +4400,9 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
     },
     "get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -4230,6 +4458,14 @@
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "requires": {
+        "get-intrinsic": "^1.1.3"
       }
     },
     "grapheme-splitter": {
@@ -4310,13 +4546,32 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
       "requires": {
-        "get-intrinsic": "^1.1.0",
+        "get-intrinsic": "^1.2.0",
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
+      }
+    },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-array-buffer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.2.0",
+        "is-typed-array": "^1.1.10"
       }
     },
     "is-bigint": {
@@ -4370,6 +4625,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
+    },
     "is-negative-zero": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -4402,6 +4662,11 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
+    },
     "is-shared-array-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
@@ -4426,6 +4691,23 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
+    },
     "is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -4434,15 +4716,29 @@
         "call-bind": "^1.0.2"
       }
     },
+    "is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
+    },
+    "isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "jose": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.12.0.tgz",
-      "integrity": "sha512-wW1u3cK81b+SFcHjGC8zw87yuyUweEFe0UJirrXEw1NasW00eF7sZjeG3SLBGz001ozxQ46Y9sofDvhBmWFtXQ=="
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.13.1.tgz",
+      "integrity": "sha512-MSJQC5vXco5Br38mzaQKiq9mwt7lwj2eXpgpRyQYNHYt2lq1PjkWa7DLXX0WVcQLE9HhMh3jPiufS7fhJf+CLQ=="
     },
     "js-cookie": {
       "version": "3.0.1",
@@ -4647,6 +4943,15 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
       "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
     },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -4840,26 +5145,26 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-router": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.0.tgz",
-      "integrity": "sha512-760bk7y3QwabduExtudhWbd88IBbuD1YfwzpuDUAlJUJ7laIIcqhMvdhSVh1Fur1PE8cGl84L0dxhR3/gvHF7A==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.9.0.tgz",
+      "integrity": "sha512-51lKevGNUHrt6kLuX3e/ihrXoXCa9ixY/nVWRLlob4r/l0f45x3SzBvYJe3ctleLUQQ5fVa4RGgJOTH7D9Umhw==",
       "requires": {
-        "@remix-run/router": "1.3.1"
+        "@remix-run/router": "1.4.0"
       }
     },
     "react-router-dom": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.0.tgz",
-      "integrity": "sha512-hQouduSTywGJndE86CXJ2h7YEy4HYC6C/uh19etM+79FfQ6cFFFHnHyDlzO4Pq0eBUI96E4qVE5yUjA00yJZGQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.9.0.tgz",
+      "integrity": "sha512-/seUAPY01VAuwkGyVBPCn1OXfVbaWGGu4QN9uj0kCPcTyNYgL1ldZpxZUpRU7BLheKQI4Twtl/OW2nHRF1u26Q==",
       "requires": {
-        "@remix-run/router": "1.3.1",
-        "react-router": "6.8.0"
+        "@remix-run/router": "1.4.0",
+        "react-router": "6.9.0"
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",
@@ -4970,6 +5275,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+    },
+    "stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "requires": {
+        "internal-slot": "^1.0.4"
+      }
     },
     "string.prototype.matchall": {
       "version": "4.0.8",
@@ -5155,6 +5468,30 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      }
+    },
+    "which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "requires": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      }
+    },
+    "which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@descope/node-sdk": "1.0.4",
-    "@descope/react-sdk": "0.1.3",
+    "@descope/node-sdk": "1.0.6",
+    "@descope/react-sdk": "1.0.0",
     "@types/node": "18.11.9",
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.8",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@descope/node-sdk": "1.0.6",
-    "@descope/react-sdk": "1.0.0",
+    "@descope/node-sdk": "1.1.0",
+    "@descope/react-sdk": "1.0.3",
     "@types/node": "18.11.9",
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.8",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,7 +7,8 @@ export default function App({ Component, pageProps }: AppProps) {
     <AuthProvider
       projectId={process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID!}
       baseUrl={process.env.NEXT_PUBLIC_DESCOPE_BASE_URL}
-      sessionTokenViaCookie
+      // use the bellow option when you need to use session token in the SSR render cycle
+      sessionTokenViaCookie 
     >
       <Component {...pageProps} />
     </AuthProvider>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,6 +7,7 @@ export default function App({ Component, pageProps }: AppProps) {
     <AuthProvider
       projectId={process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID!}
       baseUrl={process.env.NEXT_PUBLIC_DESCOPE_BASE_URL}
+      sessionTokenViaCookie
     >
       <Component {...pageProps} />
     </AuthProvider>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,9 @@ import Head from "next/head";
 import Link from "next/link";
 import { SyntheticEvent, useCallback } from "react";
 import styles from "../styles/Home.module.css";
-import { getUserDisplayName, validateRequestSession } from "../utils/auth";
+import { validateRequestSession } from "../utils/auth";
+
+const getUserDisplayName = (user: any) => user?.name || user?.externalIds?.[0] || '';
 
 export default function Home({ data }: { data: string }) {
   const { isAuthenticated } = useSession();
@@ -12,10 +14,6 @@ export default function Home({ data }: { data: string }) {
   const { logout } = useDescope();
 
   const onLogout = useCallback(() => {
-    // Delete Descope refresh token cookie.
-    // This is only required if Descope tokens are NOT managed in cookies.
-    document.cookie = "DSR=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
-
     logout();
   }, [logout]);
 

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -20,13 +20,6 @@ const DescopeWC = dynamic(
 export default function Login() {
   const router = useRouter();
   const onSuccess = useCallback(() => {
-    const refreshToken = getRefreshToken();
-    if (refreshToken) {
-      // Set refresh token on cookie so it can be used in getServerSideProps
-      // This is only requires for when Descope tokens do NOT managed already in cookies.
-      // In production, prefer managing Descope tokens in cookies.
-      document.cookie = `DSR=${refreshToken}`;
-    }
     router.push("/");
   }, [router]);
 

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,4 +1,3 @@
-import { getRefreshToken } from "@descope/react-sdk";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { useCallback } from "react";

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -11,14 +11,13 @@ export const validateRequestSession = async (req: {
   cookies: NextApiRequestCookies
 }) =>  {
   const sessionToken = req.cookies?.['DS'];
-  // TODO - need to think how to set DSR in the client side
-  const refreshToken = req.cookies?.['DSR'];
+  if (!sessionToken) {
+    return false;
+  }
   try {
-    await descopeSdk.validateAndRefreshSession(sessionToken, refreshToken);
+    await descopeSdk.validateSession(sessionToken);
   } catch (error) {
     return false;
   }
   return true;
 }
-
-export const getUserDisplayName = (user: any) => user?.name || user?.externalIds?.[0] || '';


### PR DESCRIPTION
- update descope deps
- moved `getUserDisplayName` to the component that used it (Webpack does not do proper tree-shaking without it - see [this](https://nextjs.org/docs/messages/module-not-found)
- change sample to manage session on cookie, passing refresh token to the next backend does not make sense, it will be improved once Descope will support a dedicated `next` sdk