### PR TITLE
chore: Update GitHub Actions workflow to run every weekend

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Cypress Tests
-on: [push]
+on:
+  push:                        # runs on every push
+  schedule:
+    - cron: '0 3 * * 1'        # runs every Monday at 3AM UTC
 jobs:
   cypress-run:
     name: E2E Tests

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     },
   },
   env: {
-    descope_project_id: process.env.DESCOPE_PROJECT_ID,
+    descope_project_id: process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID,
     descope_management_key: process.env.DESCOPE_MANAGEMENT_KEY
   },
 });


### PR DESCRIPTION
Fixes [Issue](https://github.com/descope/etc/issues/4290)
Added a cron string to run the e2e tests weekly on Monday at 3AM